### PR TITLE
mapping new layout for profile page - showing charges, more details etc

### DIFF
--- a/client/src/components/Content/HomeOverview/HomeOverview.jsx
+++ b/client/src/components/Content/HomeOverview/HomeOverview.jsx
@@ -4,12 +4,26 @@ import { Doughnut } from 'react-chartjs-2';
 import { Paper, Grid } from '@material-ui/core';
 import OverviewMobileSub from './OverviewMobileSub';
 import moment from 'moment';
+import { useSelector, useDispatch} from 'react-redux';
+import {filterExpenses} from '../../../redux/actions';
 
-const Overview = ({user}) => {
+const Overview = () => {
   const [monthlyGraph, setMonthlyGraph] = useState(null);
   const [nonMonthlyGraph, setNonMonthlyGraph] = useState(null);
   const [recurringTotal, setRecurringTotal] = useState(null);
   const [nonRecurringTotal, setNonRecurringTotal] = useState(null);
+  const dispatch = useDispatch();
+  const expenseDetails = useSelector(state => state.expenseDetails);
+  const user = useSelector(state => state.user)
+
+  // function expenseObj(finances, living, health, leisure, travel){
+  //   this.financesTotal = finances,
+  //   this.livingTotal = living,
+  //   this.healthTotal = health,
+  //   this.leisureTotal = leisure,
+  //   this.travelTotal = travel
+  // }
+  //constructor for later - fixing state on child component then circling back
   
   useEffect(() => {
     if (user.expense) {
@@ -65,17 +79,23 @@ const Overview = ({user}) => {
             return item;
         }
       });
-
-      
       expenseSumHelper(recurringExpenseObj, true);
       expenseSumHelper(nonRecurringExpenseObj, false);
       graphInitHelper(recurringExpenseObj, true);
       graphInitHelper(nonRecurringExpenseObj, false);
     }
-  }, [user]);
+  }, []);
+
+  useEffect(()=> {
+    let currentMonthExpenses = user.expense.map(charge =>
+      moment(charge.date).format('MMMM') === moment(Date.now()).format('MMMM'))
+    dispatch(filterExpenses(currentMonthExpenses))
+    console.log(currentMonthExpenses, expenseDetails)
+    //pausing here, successfully triggered but showing empty objects
+  }, [user.expense])
 
   const graphInitHelper = (expenseObj, recurring)=> {
-    console.log('graphinithelper function', expenseObj, recurring)
+    console.log('graphinithelper ran')
     let graph = {
       labels: ['Finances', 'Living', 'Health', 'Leisure', 'Travel'],
       datasets: [

--- a/client/src/components/Content/HomeOverview/OverviewMobileSub.jsx
+++ b/client/src/components/Content/HomeOverview/OverviewMobileSub.jsx
@@ -3,6 +3,7 @@ import { Grid, Paper } from '@material-ui/core';
 import moment from 'moment';
 import { useEffect } from 'react';
 
+
 const OverviewMobileSub = ({ user, nrTotal, rTotal }) => {
 
   let format$ = input => {
@@ -23,8 +24,17 @@ const OverviewMobileSub = ({ user, nrTotal, rTotal }) => {
     <Grid container className='ovSubC'>
       {/* Mapping new layout */}
       <Grid item>
-        <Paper>Current user's salary and monthly income</Paper>
-        <Paper>Recurring Charges and Nonrecurring Charge amount = total charges</Paper>
+        <Paper>
+          <h3>Your current salary:</h3>
+          <p>{format$(user.salary)}</p>
+          <h3>Projected monthly income:</h3>
+          <p>{format$(user.salary / 12)}</p>
+        </Paper>
+        <Paper>
+          Recurring Charges and Nonrecurring Charge amount = total charges
+        
+        
+        </Paper>
         <Paper>Income - Total Charges = Budget remaining</Paper>
       </Grid>
       <Grid item>

--- a/client/src/components/Content/HomeOverview/OverviewMobileSub.jsx
+++ b/client/src/components/Content/HomeOverview/OverviewMobileSub.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Grid, Paper } from '@material-ui/core';
 import moment from 'moment';
+import { useEffect } from 'react';
 
 const OverviewMobileSub = ({ user, nrTotal, rTotal }) => {
+
   let format$ = input => {
     return input.toLocaleString('en-US', {
       style: 'currency',
@@ -13,57 +15,26 @@ const OverviewMobileSub = ({ user, nrTotal, rTotal }) => {
   let formatP = input => {
     let perc = (input / (user.salary / 12)).toFixed(2) * 100;
     return (
-      <p className='ovPercP'>
-        <span className='percSpan'>{perc}%</span> of your income.
-      </p>
+      <span>{Math.round(perc)}%  of your income.</span>
     );
   };
 
   return (
     <Grid container className='ovSubC'>
-      <Grid item xs={12} className='ovSubI'>
-        <Paper className='ovP'>
-          <header>
-            <span className='ovI'>Estimated monthly income: </span>
-            {format$(user.salary / 12)}
-          </header>
+      {/* Mapping new layout */}
+      <Grid item>
+        <Paper>Current user's salary and monthly income</Paper>
+        <Paper>Recurring Charges and Nonrecurring Charge amount = total charges</Paper>
+        <Paper>Income - Total Charges = Budget remaining</Paper>
+      </Grid>
+      <Grid item>
+        <Paper>
+          Material ui dropdown list showing all charges that classify under recurring
         </Paper>
       </Grid>
-      <Grid item xs={12} className='ovSubI'>
-        <Paper className='ovP'>
-          <header>
-            <span className='ovI'>Total monthly charges: </span>
-            {format$(rTotal)}
-          </header>
-          {formatP(rTotal)}
-        </Paper>
-      </Grid>
-      <Grid item xs={12} className='ovSubI'>
-        <Paper className='ovP'>
-          <header>
-            <span className='ovI'>
-              Total msc. Charges from {moment(Date.now()).format('MMMM')}:{' '}
-            </span>
-            {format$(nrTotal)}
-          </header>
-          {formatP(nrTotal)}
-        </Paper>
-      </Grid>
-      <Grid item xs={12} className='ovSubI'>
-        <Paper className='ovP'>
-          <header>
-            <span className='ovI'>Total charges this month: </span>
-            {format$(rTotal + nrTotal)}
-          </header>
-          {formatP(rTotal + nrTotal)}
-        </Paper>
-      </Grid>
-      <Grid item xs={12} className='ovSubI'>
-        <Paper className='ovP'>
-          <header>
-            <span>Budget remaining: </span>
-            {format$(user.salary / 12 - (rTotal + nrTotal))}
-          </header>
+      <Grid item>
+        <Paper>
+          Material ui dropdown list showing all charges that are not recurring
         </Paper>
       </Grid>
     </Grid>
@@ -71,3 +42,38 @@ const OverviewMobileSub = ({ user, nrTotal, rTotal }) => {
 };
 
 export default OverviewMobileSub;
+
+
+
+// <Grid item xs={12} className='ovSubI'>
+//         <Paper>
+//           <p><span className='ovI'>Estimated monthly income: </span> {format$(user.salary / 12)}</p>
+//         </Paper>
+//         <Paper>
+
+//         </Paper>
+//         <Paper>
+
+//         </Paper>
+//       </Grid>
+//       <Grid item xs={12} className='ovSubI'>
+//         <Paper>
+//         <p><span className='ovI'>Total monthly charges: </span>{format$(rTotal)} - {formatP(rTotal)}</p>
+//         </Paper>
+//       </Grid>
+//       <Grid item xs={12} className='ovSubI'>
+//         <span className='ovI'>
+//               Total msc. Charges from {moment(Date.now()).format('MMMM')}:{' '}
+//         </span>
+//         {format$(nrTotal)}
+//         {formatP(nrTotal)}
+//       </Grid>
+//       <Grid item xs={12} className='ovSubI'>
+//         <span className='ovI'>Total charges this month: </span>
+//         {format$(rTotal + nrTotal)}
+//         {formatP(rTotal + nrTotal)}
+//       </Grid>
+//       <Grid item xs={12} className='ovSubI'>
+//         <span>Budget remaining: </span>
+//           {format$(user.salary / 12 - (rTotal + nrTotal))}
+//       </Grid>

--- a/client/src/redux/actions/index.js
+++ b/client/src/redux/actions/index.js
@@ -2,7 +2,9 @@ import API from '../../clientRoutes/API';
 
 export const getData = (id) =>{
     return (dispatch)=> {
-        return API.getHomeDisplay({id}).then(res => dispatch(initUser(res.data)))
+        return API.getHomeDisplay({id}).then(res => {
+            dispatch(initUser(res.data))
+        })
     }
 }
 
@@ -17,5 +19,31 @@ export const updateProfile = (data) => {
     return {
         type: 'Update',
         payload: data
+    }
+}
+
+export const filterExpenses = (expenses) => {
+    function expenseDetail(expenseArr, total ){
+        this.list = expenseArr;
+        this.total = total;
+    }
+    
+    let recurring = expenses.filter(expense => expense.recurring);
+    let nonRecurring = expenses.filter(expense => !expense.recurring);
+
+    function getTotal(arr){
+        let total = 0;
+        for(let expense of arr){
+            total += expense.amount;
+        }
+        return total;
+    }
+
+    return {
+        type: 'FilterExpenses',
+        payload: {
+            recDetal: new expenseDetail(recurring, getTotal(recurring)),
+            nonRecDetail: new expenseDetail(nonRecurring, getTotal(nonRecurring))
+        }
     }
 }

--- a/client/src/redux/reducers/expenseReducer.js
+++ b/client/src/redux/reducers/expenseReducer.js
@@ -1,0 +1,17 @@
+const initialState = {
+    filteredExpenses: {},
+    filteredCategoryData: {}
+}
+
+const expenseReducer = (state = initialState, action) => {
+    switch(action.type){
+        case 'FilterExpenses':
+            return {...state, filteredExpenses: action.payload};
+        case 'GetFilteredCategoryData':
+            return state;
+        default:
+            return state;
+    }
+}
+
+export default expenseReducer;

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -1,10 +1,12 @@
 import contentReducer from './contentReducer';
 import userReducer from './userReducer';
+import expenseReducer from './expenseReducer';
 import {combineReducers} from 'redux';
 
 const rootReducer = combineReducers({
     content: contentReducer,
-    user: userReducer
+    user: userReducer,
+    expenseDetails: expenseReducer
 })
 
 export default rootReducer;

--- a/client/src/redux/reducers/userReducer.js
+++ b/client/src/redux/reducers/userReducer.js
@@ -1,5 +1,3 @@
-import API from '../../clientRoutes/API';
-
 const userReducer = (state = {}, action)=> {
     switch(action.type){
         case 'Init':


### PR DESCRIPTION
Mapping a new layout for "Overviewmobile" component - misleading component name but will resolve later.

Planning on new layout having a dropdown for each recurring/nonrecurring category to show charges on profile screen without the user having to go to individual category. With a cleaner breakdown of their income, total charges, and their income remaining after the current charges. 

Needs additional functionality but thinking of what to add.